### PR TITLE
BUGFIX: Calculate DateInterval in tests based on Now

### DIFF
--- a/Tests/Functional/Retry/TestCase.php
+++ b/Tests/Functional/Retry/TestCase.php
@@ -41,7 +41,7 @@ class TestCase extends JobQueueTestCase
     protected function numberOfSecondsInterval(int $numberOfSeconds): DateInterval
     {
         $denormalizedDiff = DateInterval::createFromDateString($numberOfSeconds . ' seconds');
-        $earlier = new DateTimeImmutable();
+        $earlier = $this->now;
         $later = $earlier->add($denormalizedDiff);
         $normalizedDiff = $later->diff($earlier);
         return $normalizedDiff;


### PR DESCRIPTION
The retry test expects a certain number of seconds between the
initial scheduling and the retry value.

To have a human readable understanding of how long a retried
command should be deferred in contrast to how long it is actually
deffered (that's what retry test does), the test doesn't work on
number of seconds but on a PHP DateInterval object.

The internal data structure of that date interval object is based
on the current time zone because 3276800 seconds are always 37.9
days on one hand, but either 1 month and 6 days or 1 month and 7
days on the other, depending on which month the vaue should be
added to.