### PR TITLE
feat: Introduce "groupName" property of scheduled jobs

### DIFF
--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -11,16 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ 7.4, 8.0, 8.1 ]
-        flow-version: [ 5.3, 6.3, 7.3, 8.0 ]
+        flow-version: [ 6.3, 7.3, 8.0 ]
         mysql-version: [5.7, 8.0]
         exclude:
-          # Disable Flow 5.3 and 6.3 on PHP 8.0, as only ^7.2 is supported
-          - php-version: 8.0
-            flow-version: 5.3
+          # Disable Flow 6.3 on PHP 8.0, as only ^7.2 is supported
           - php-version: 8.0
             flow-version: 6.3
-          - php-version: 8.1
-            flow-version: 5.3
           - php-version: 8.1
             flow-version: 6.3
 

--- a/Classes/AsScheduledJob/CopyToScheduler.php
+++ b/Classes/AsScheduledJob/CopyToScheduler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\AsScheduledJob;
+
+
+use DateTimeImmutable;
+use Flowpack\JobQueue\Common\Job\JobInterface;
+use Flowpack\JobQueue\Common\Queue\FakeQueue;
+use Flowpack\JobQueue\Common\Queue\Message;
+use Flowpack\JobQueue\Common\Queue\QueueInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
+
+/**
+ * @Flow\Aspect
+ * @Flow\Scope("singleton")
+ */
+class CopyToScheduler
+{
+    private Scheduler $scheduler;
+
+    public function injectScheduler(Scheduler $scheduler)
+    {
+        $this->scheduler = $scheduler;
+    }
+
+    /**
+     * @Flow\Around("within(Netlogix\JobQueue\Scheduled\AsScheduledJob\ScheduledJobInterface) && within(Flowpack\JobQueue\Common\Job\JobInterface) && method(.*->execute())")
+     */
+    public function execute(JoinPointInterface $joinPoint): bool
+    {
+        $job = $joinPoint->getProxy();
+        assert($job instanceof JobInterface);
+
+        $queue = $joinPoint->getMethodArgument('queue');
+        assert($queue instanceof QueueInterface);
+
+        if ($queue instanceof FakeQueue && $queue->getName() === SchedulingInformation::QUEUE_NAME) {
+            // This is the call done by the scheduling worker, so actually work on the job instead of scheduling it.
+            return $joinPoint->getAdviceChain()->proceed($joinPoint);
+        }
+
+        $scheduledJob = $this->convertMessageToScheduledJob($job);
+        if (!$scheduledJob) {
+            // The job decided to not provide scheduling information, so don't schedule it.
+            return $joinPoint->getAdviceChain()->proceed($joinPoint);
+        }
+
+        $this->scheduler->schedule($scheduledJob);
+
+        return true;
+    }
+
+    protected function convertMessageToScheduledJob(
+        ScheduledJobInterface $job
+    ): ?ScheduledJob {
+        assert($job instanceof JobInterface);
+        $schedulingInformation = $job->getSchedulingInformation();
+        if ($schedulingInformation === null) {
+            return null;
+        }
+        return new ScheduledJob(
+            $job,
+            SchedulingInformation::QUEUE_NAME,
+            $schedulingInformation->getDueDate(),
+            $schedulingInformation->getGroupName(),
+            $schedulingInformation->getIdentifier()
+        );
+    }
+}

--- a/Classes/AsScheduledJob/ScheduledJobInterface.php
+++ b/Classes/AsScheduledJob/ScheduledJobInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\AsScheduledJob;
+
+
+use Flowpack\JobQueue\Common\Job\JobInterface;
+
+/**
+ * Jobs implementing this interface will be moved into the scheduler
+ */
+interface ScheduledJobInterface
+{
+    /**
+     * Returns data on how to convert this job into a ScheduledJob
+     *
+     * If no scheduling information is returned, the job must not
+     * be converted into a scheduled job.
+     *
+     * This can be used to enable or disable scheduling for a given
+     * job or job type either by job content or by configuration.
+     *
+     * @return SchedulingInformation|null
+     */
+    public function getSchedulingInformation(): ?SchedulingInformation;
+}

--- a/Classes/AsScheduledJob/SchedulingInformation.php
+++ b/Classes/AsScheduledJob/SchedulingInformation.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\AsScheduledJob;
+
+use DateTimeImmutable;
+use Neos\Flow\Annotations as Flow;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class SchedulingInformation
+{
+    public const QUEUE_NAME = 'netlogix-scheduled-fakequeue';
+
+    private $identifier;
+
+    private $groupName;
+
+    private $dueDate;
+
+    public function __construct(
+        string $identifier,
+        string $groupName = Scheduler::DEFAULT_GROUP_NAME,
+        DateTimeImmutable $dueDate = null
+    ) {
+        $this->identifier = $identifier;
+        $this->groupName = $groupName;
+        $this->dueDate = $dueDate;
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    public function getGroupName()
+    {
+        return $this->groupName;
+    }
+
+    public function getDueDate(): DateTimeImmutable
+    {
+        return $this->dueDate ? $this->dueDate : new DateTimeImmutable('now');
+    }
+}

--- a/Classes/Domain/Model/ScheduledJob.php
+++ b/Classes/Domain/Model/ScheduledJob.php
@@ -12,7 +12,13 @@ use Neos\Flow\Utility\Algorithms;
 /**
  * @Flow\Entity
  * @Flow\Proxy(false)
- * @ORM\Table(name=ScheduledJob::TABLE_NAME)
+ * @ORM\Table(
+ *     name=ScheduledJob::TABLE_NAME,
+ *     indexes={
+ *          @ORM\Index(name="idx_groupname", columns={"groupname", "identifier"}),
+ *          @ORM\Index(name="idx_claimed", columns={"claimed", "identifier"})
+ *     }
+ * )
  */
 class ScheduledJob
 {
@@ -20,8 +26,14 @@ class ScheduledJob
 
     /**
      * @var string
-     * @ORM\Id
+     * @ORM\Column(name="groupname", length=36, options={"fixed": true, "default": "default"})
+     */
+    protected $groupName = 'default';
+
+    /**
+     * @var string
      * @Flow\Identity
+     * @ORM\Id
      */
     protected $identifier;
 
@@ -57,6 +69,7 @@ class ScheduledJob
         JobInterface $job,
         string $queue,
         DateTimeImmutable $duedate,
+        string $groupName,
         string $identifier = '',
         int $incarnation = 0,
         string $claimed = ''
@@ -64,9 +77,15 @@ class ScheduledJob
         $this->job = $job;
         $this->queue = $queue;
         $this->duedate = $duedate;
+        $this->groupName = $groupName;
         $this->identifier = $identifier ?: Algorithms::generateUUID();
         $this->incarnation = $incarnation;
         $this->claimed = $claimed;
+    }
+
+    public function getGroupName(): string
+    {
+        return $this->groupName;
     }
 
     public function getIdentifier(): string

--- a/Classes/Domain/Retry.php
+++ b/Classes/Domain/Retry.php
@@ -19,8 +19,7 @@ class Retry
     private const DEFAULT_BEHAVIOR = [
         'backoffStrategy' => self::DEFAULT_BACKOFF_STRATEGY,
         'numberOfRetries' => self::DEFAULT_NUMBER_OF_RETRIES,
-        'retryInterval' => self::DEFAULT_RETRY_INTERVAL,
-        'keepFailedJobs' => self::DEFAULT_KEEP_FAILED_JOBS,
+        'retryInterval' => self::DEFAULT_RETRY_INTERVAL
     ];
 
     /**
@@ -112,6 +111,7 @@ class Retry
                 $job->getJob(),
                 $job->getQueueName(),
                 $nextDueDate,
+                $job->getGroupName(),
                 $job->getIdentifier(),
                 $nextIncarnation
             );

--- a/Configuration/Settings.FakeQueue.yaml
+++ b/Configuration/Settings.FakeQueue.yaml
@@ -1,0 +1,10 @@
+Flowpack:
+  JobQueue:
+    Common:
+      queues:
+
+        # For jobs being handled via "as scheduled", this queue immediately calls for execution
+
+        'netlogix-scheduled-fakequeue':
+          className: 'Flowpack\JobQueue\Common\Queue\FakeQueue'
+          executeIsolated: false

--- a/Configuration/Settings.Groups.yaml
+++ b/Configuration/Settings.Groups.yaml
@@ -1,0 +1,21 @@
+Netlogix:
+  JobQueue:
+    Scheduled:
+
+      groupNames:
+
+        # For parallel execution of jobs, multiple workers are necessary.
+        # All jobs in the same queue have the same priority and are executed in the order they were scheduled.
+        #
+        # The rough idea is:
+        # * Use one group for short running jobs
+        # * Use another group for long running jobs
+        # * Use another group for jobs that occur very often
+        # * Use another group for jobs that occur very seldom
+        #
+        # This way, jobs are only blocked by others that have basically the same priority, but no very important
+        # but short running job can be blocked by others that run for a long time but aren't important at all.
+        #
+        # All groups need to be defined and enabled.
+        # Other strings can neither be used for scheduling jobs nor for having workers execute them.
+        default: true

--- a/Configuration/Settings.Supervisor.yaml
+++ b/Configuration/Settings.Supervisor.yaml
@@ -6,7 +6,8 @@ Netlogix:
       jobqueue-scheduled-jobs:
 
         # Mandatory script to be executed and watched by supervisor
-        command: 'bash -c "sleep 5 && exec ./flow scheduler:pollforincomingjobs"'
+        # This will only work on one job group, so add multiple of those for multiple groups
+        command: 'bash -c "sleep 5 && exec ./flow scheduler:pollforincomingjobs --groupName default"'
 
         # Programs need names for supervisor to distinguish and assign to groups
         name: 'jobqueue-scheduled-jobs'

--- a/Configuration/Testing/Settings.Groups.yaml
+++ b/Configuration/Testing/Settings.Groups.yaml
@@ -1,0 +1,7 @@
+Netlogix:
+  JobQueue:
+    Scheduled:
+
+      groupNames:
+
+        additional-group: true

--- a/Migrations/Mysql/Version20240719144459.php
+++ b/Migrations/Mysql/Version20240719144459.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Introduce different groups for scheduled jobs where every group needs its own worker.
+ */
+final class Version20240719144459 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() != 'mysql',
+            'Migration can only be executed safely on "mysql".'
+        );
+
+        $this->addSql('ALTER TABLE netlogix_jobqueue_scheduled_job ADD groupname CHAR(36) DEFAULT \'default\' NOT NULL');
+        $this->addSql('CREATE INDEX idx_groupname ON netlogix_jobqueue_scheduled_job (groupname, identifier)');
+        $this->addSql('CREATE INDEX idx_claimed ON netlogix_jobqueue_scheduled_job (claimed, identifier)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() != 'mysql',
+            'Migration can only be executed safely on "mysql".'
+        );
+
+        $this->addSql('DROP INDEX idx_groupname ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('DROP INDEX idx_claimed ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('ALTER TABLE netlogix_jobqueue_scheduled_job DROP groupname');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ putting a job into a RabbitMQ and another flow app consuming it.
 Previously the only implementation would be a regular jobqueue worker, which neither
 provides a way to delay execution nor a deduplication feature.
 
-Now every job can simply implement the `ScheduledJobInterface`. When is `execute()`
+Now every job can simply implement the `ScheduledJobInterface`. When `execute()`
 is triggered, it's now moved over to a scheduled jobs queue.
 
 The job itself must provide all necessary details about how to schedule its execution.
@@ -125,7 +125,7 @@ abstract class AutoScheduledJob implements ScheduledJobInterface, JobInterface {
     {
         return SchedulingInformation(
             '97528fab-c199-4f87-b1a5-4074f1e98749',
-            'default-grouo',
+            'default-group',
             new DateTimeImmutable('now')
         );
     }

--- a/README.md
+++ b/README.md
@@ -104,3 +104,30 @@ This is currently done via cronjobs.
 The internal scheduling mechanism will make sure only those jobs are passed from the
 scheduler to the job queue which are "due" according to their individual due date
 values.
+
+
+## Automatically schedule jobs
+
+Some jobs originate from foreign applications. An example would be one flow app
+putting a job into a RabbitMQ and another flow app consuming it.
+
+Previously the only implementation would be a regular jobqueue worker, which neither
+provides a way to delay execution nor a deduplication feature.
+
+Now every job can simply implement the `ScheduledJobInterface`. When is `execute()`
+is triggered, it's now moved over to a scheduled jobs queue.
+
+The job itself must provide all necessary details about how to schedule its execution.
+
+```php
+abstract class AutoScheduledJob implements ScheduledJobInterface, JobInterface {
+    public function getSchedulingInformation(): ?SchedulingInformation
+    {
+        return SchedulingInformation(
+            '97528fab-c199-4f87-b1a5-4074f1e98749',
+            'default-grouo',
+            new DateTimeImmutable('now')
+        );
+    }
+}
+```

--- a/Tests/Functional/AsScheduledJob/CopyToSchedulerTest.php
+++ b/Tests/Functional/AsScheduledJob/CopyToSchedulerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\AsScheduledJob;
+
+use DateTimeImmutable;
+use Flowpack\JobQueue\Common\Job\JobInterface;
+use Flowpack\JobQueue\Common\Queue\FakeQueue;
+use Flowpack\JobQueue\Common\Queue\QueueInterface;
+use Neos\Flow\Aop\Advice\AdviceChain;
+use Neos\Flow\Aop\JoinPoint;
+use Netlogix\JobQueue\Scheduled\AsScheduledJob\CopyToScheduler;
+use Netlogix\JobQueue\Scheduled\AsScheduledJob\SchedulingInformation;
+use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
+use Netlogix\JobQueue\Scheduled\Tests\Functional\TestCase;
+
+class CopyToSchedulerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function ScheduledJobs_on_the_internal_fake_queue_are_not_redirected(): void
+    {
+        $job = $this->createMock(TestingScheduledJobInterface::class);
+
+        $joinPoint = $this->createMock(JoinPoint::class);
+        $joinPoint
+            ->expects(self::once())
+            ->method('getProxy')
+            ->willReturn($job);
+
+        $fakeQueue = $this->createMock(FakeQueue::class);
+        $fakeQueue
+            ->expects(self::once())
+            ->method('getName')
+            ->willReturn(SchedulingInformation::QUEUE_NAME);
+
+        $joinPoint
+            ->expects(self::once())
+            ->method('getMethodArgument')
+            ->withAnyParameters('queue')
+            ->willReturn($fakeQueue);
+
+        $adviceChain = $this->createMock(AdviceChain::class);
+        $adviceChain
+            ->expects(self::once())
+            ->method('proceed')
+            ->willReturn(true);
+
+        $joinPoint
+            ->expects(self::once())
+            ->method('getAdviceChain')
+            ->willReturn($adviceChain);
+
+        $copyToSchedulerAspect = new CopyToScheduler();
+        $copyToSchedulerAspect->execute($joinPoint);
+    }
+
+    /**
+     * @test
+     */
+    public function Jobs_providing_no_scheduling_information_are_not_redirected(): void
+    {
+        $job = $this->createMock(TestingScheduledJobInterface::class);
+
+        $joinPoint = $this->createMock(JoinPoint::class);
+        $joinPoint
+            ->expects(self::once())
+            ->method('getProxy')
+            ->willReturn($job);
+
+        $queue = $this->createMock(QueueInterface::class);
+
+        $joinPoint
+            ->expects(self::once())
+            ->method('getMethodArgument')
+            ->withAnyParameters('queue')
+            ->willReturn($queue);
+
+        $adviceChain = $this->createMock(AdviceChain::class);
+        $adviceChain
+            ->expects(self::once())
+            ->method('proceed')
+            ->willReturn(true);
+
+        $joinPoint
+            ->expects(self::once())
+            ->method('getAdviceChain')
+            ->willReturn($adviceChain);
+
+        $job
+            ->expects(self::once())
+            ->method('getSchedulingInformation')
+            ->willReturn(null);
+
+        $copyToSchedulerAspect = new CopyToScheduler();
+        $copyToSchedulerAspect->execute($joinPoint);
+    }
+
+    /**
+     * @test
+     */
+    public function Jobs_with_schedulingInformation_get_redirected_to_the_scheduler(): void
+    {
+        $job = $this->createMock(TestingScheduledJobInterface::class);
+
+        $joinPoint = $this->createMock(JoinPoint::class);
+        $joinPoint
+            ->expects(self::once())
+            ->method('getProxy')
+            ->willReturn($job);
+
+        $queue = $this->createMock(QueueInterface::class);
+
+        $joinPoint
+            ->expects(self::once())
+            ->method('getMethodArgument')
+            ->withAnyParameters('queue')
+            ->willReturn($queue);
+
+        $schedulingInformation = new SchedulingInformation(
+            'identifier-223638b6-684b-49aa-8529-68040ef66679',
+            'group-5cbaf1ca-b09d-4a0c-99d8-ea2ef5a6b142',
+            new DateTimeImmutable('2024-07-24T16:59:01+02:00')
+        );
+
+        $job
+            ->expects(self::once())
+            ->method('getSchedulingInformation')
+            ->willReturn($schedulingInformation);
+
+        $scheduler = $this->createMock(Scheduler::class);
+        $scheduler
+            ->expects(self::once())
+            ->method('schedule')
+            ->willReturnCallback(function (ScheduledJob $scheduledJob) use ($schedulingInformation) {
+                self::assertEquals(SchedulingInformation::QUEUE_NAME, $scheduledJob->getQueueName());
+                self::assertEquals($schedulingInformation->getIdentifier(), $scheduledJob->getIdentifier());
+                self::assertEquals($schedulingInformation->getGroupName(), $scheduledJob->getGroupName());
+                self::assertEquals($schedulingInformation->getDueDate(), $scheduledJob->getDueDate());
+            });
+
+        $copyToSchedulerAspect = new CopyToScheduler();
+        $copyToSchedulerAspect->injectScheduler($scheduler);
+        $copyToSchedulerAspect->execute($joinPoint);
+    }
+}

--- a/Tests/Functional/AsScheduledJob/TestingScheduledJobInterface.php
+++ b/Tests/Functional/AsScheduledJob/TestingScheduledJobInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\AsScheduledJob;
+
+use Flowpack\JobQueue\Common\Job\JobInterface;
+use Netlogix\JobQueue\Scheduled\AsScheduledJob\ScheduledJobInterface;
+
+interface TestingScheduledJobInterface extends JobInterface, ScheduledJobInterface {
+
+}

--- a/Tests/Functional/FailTest.php
+++ b/Tests/Functional/FailTest.php
@@ -6,6 +6,7 @@ namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class FailTest extends TestCase
 {
@@ -30,6 +31,7 @@ class FailTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             100,
             'claim'
@@ -57,6 +59,7 @@ class FailTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             100
         );

--- a/Tests/Functional/Groups/RetrievingTest.php
+++ b/Tests/Functional/Groups/RetrievingTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Groups;
+
+use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
+use Netlogix\JobQueue\Scheduled\Tests\Functional\TestCase;
+
+class RetrievingTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function Known_groups_can_be_worked_on(): void
+    {
+        $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        $this->scheduler->next('additional-group');
+
+       $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @test
+     */
+    public function Unknown_groups_can_be_worked_on(): void
+    {
+        self::expectExceptionCode(1721393320);
+        self::expectExceptionMessage('Group name "non-existing-group" is not active');
+
+        $this->scheduler->next('non-existing-group');
+    }
+
+    /**
+     * @test
+     */
+    public function Additional_groups_dont_interfere_with_default_group_jobs(): void
+    {
+        $this->scheduler->schedule(
+            new ScheduledJob(
+                self::getJobQueueJob(),
+                self::getQueueName(),
+                self::getDueDate(),
+                'default',
+                'default-job-identifier'
+            )
+        );
+
+        $this->scheduler->schedule(
+            new ScheduledJob(
+                self::getJobQueueJob(),
+                self::getQueueName(),
+                self::getDueDate(),
+                'additional-group',
+                'additional-job-identifier'
+            )
+        );
+
+        $job = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        $notAJob = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+
+        self::assertInstanceOf(ScheduledJob::class, $job);
+        self::assertEquals('default-job-identifier', $job->getIdentifier());
+
+        self::assertNull($notAJob);
+    }
+
+    /**
+     * @test
+     */
+    public function Default_group_jobs_are_not_covered_by_additional_group_workers(): void
+    {
+        $this->scheduler->schedule(
+            new ScheduledJob(
+                self::getJobQueueJob(),
+                self::getQueueName(),
+                self::getDueDate(),
+                'default',
+                'default-job-identifier'
+            )
+        );
+
+        $this->scheduler->schedule(
+            new ScheduledJob(
+                self::getJobQueueJob(),
+                self::getQueueName(),
+                self::getDueDate(),
+                'additional-group',
+                'additional-job-identifier'
+            )
+        );
+
+        $job = $this->scheduler->next('additional-group');
+        $notAJob = $this->scheduler->next('additional-group');
+
+        self::assertInstanceOf(ScheduledJob::class, $job);
+        self::assertEquals('additional-job-identifier', $job->getIdentifier());
+
+        self::assertNull($notAJob);
+    }
+}

--- a/Tests/Functional/Groups/SchedulingTest.php
+++ b/Tests/Functional/Groups/SchedulingTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Groups;
+
+use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Tests\Functional\TestCase;
+
+class SchedulingTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function Scheduling_works_for_different_groups(): void
+    {
+        $scheduledJob = fn(string $groupName) => $this->scheduler->schedule(
+            new ScheduledJob(
+                self::getJobQueueJob(),
+                self::getQueueName(),
+                self::getDueDate(),
+                $groupName
+            )
+        );
+        $scheduledJob('default');
+        $scheduledJob('additional-group');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @test
+     */
+    public function Scheduling_on_arbitrary_group_identifiers_fails(): void
+    {
+        self::expectExceptionCode(1721393320);
+        self::expectExceptionMessage('Group name "non-existing-group" is not active');
+
+        $this->scheduler->schedule(
+            new ScheduledJob(
+                self::getJobQueueJob(),
+                self::getQueueName(),
+                self::getDueDate(),
+                'non-existing-group'
+            )
+        );
+    }
+}

--- a/Tests/Functional/ReleaseTest.php
+++ b/Tests/Functional/ReleaseTest.php
@@ -6,6 +6,7 @@ namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class ReleaseTest extends TestCase
 {
@@ -30,6 +31,7 @@ class ReleaseTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             100,
             'claim'
@@ -53,6 +55,7 @@ class ReleaseTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             100
         );

--- a/Tests/Functional/RetrievingTest.php
+++ b/Tests/Functional/RetrievingTest.php
@@ -5,6 +5,7 @@ namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
 
 use DateTimeImmutable;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class RetrievingTest extends TestCase
 {
@@ -25,7 +26,7 @@ class RetrievingTest extends TestCase
      */
     public function Without_scheduled_jobs_there_can_be_none_retrieved(): void
     {
-        $job = $this->scheduler->next();
+        $job = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
 
         self::assertNull($job);
     }
@@ -35,7 +36,7 @@ class RetrievingTest extends TestCase
      */
     public function Without_scheduled_jobs_none_can_be_found_by_identifier(): void
     {
-        self::assertFalse($this->scheduler->isScheduled('my-identifier'));
+        self::assertFalse($this->scheduler->isScheduled(Scheduler::DEFAULT_GROUP_NAME, 'my-identifier'));
     }
 
     /**
@@ -48,11 +49,12 @@ class RetrievingTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 $this->now->modify('+ 1 day'),
+                Scheduler::DEFAULT_GROUP_NAME,
                 'my-identifier'
             )
         );
 
-        self::assertTrue($this->scheduler->isScheduled('my-identifier'));
+        self::assertTrue($this->scheduler->isScheduled(Scheduler::DEFAULT_GROUP_NAME, 'my-identifier'));
     }
 
     /**
@@ -64,11 +66,12 @@ class RetrievingTest extends TestCase
             new ScheduledJob(
                 self::getJobQueueJob(),
                 self::getQueueName(),
-                $this->now->modify('+ 1 day')
+                $this->now->modify('+ 1 day'),
+            Scheduler::DEFAULT_GROUP_NAME
             )
         );
 
-        $retrievedJob = $this->scheduler->next();
+        $retrievedJob = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
 
         self::assertNull($retrievedJob);
     }
@@ -81,11 +84,12 @@ class RetrievingTest extends TestCase
         $scheduledJob = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
-            $this->now->modify('- 1 day')
+            $this->now->modify('- 1 day'),
+            Scheduler::DEFAULT_GROUP_NAME
         );
         $this->scheduler->schedule($scheduledJob);
 
-        $retrievedJob = $this->scheduler->next();
+        $retrievedJob = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
 
         self::assertInstanceOf(ScheduledJob::class, $retrievedJob);
         assert($retrievedJob instanceof ScheduledJob);
@@ -101,12 +105,13 @@ class RetrievingTest extends TestCase
             new ScheduledJob(
                 self::getJobQueueJob(),
                 self::getQueueName(),
-                self::getDueDate()
+                self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME
             )
         );
 
-        $retrievedJob1 = $this->scheduler->next();
-        $retrievedJob2 = $this->scheduler->next();
+        $retrievedJob1 = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        $retrievedJob2 = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
 
         self::assertNotNull($retrievedJob1);
         self::assertNull($retrievedJob2);
@@ -120,11 +125,12 @@ class RetrievingTest extends TestCase
         $scheduledJob = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
-            $this->now->modify('- 1 day')
+            $this->now->modify('- 1 day'),
+            Scheduler::DEFAULT_GROUP_NAME
         );
         $this->scheduler->schedule($scheduledJob);
 
-        $retrievedJob = $this->scheduler->next();
+        $retrievedJob = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
 
         self::assertInstanceOf(ScheduledJob::class, $retrievedJob);
         assert($retrievedJob instanceof ScheduledJob);

--- a/Tests/Functional/Retry/ExponentialRetryTest.php
+++ b/Tests/Functional/Retry/ExponentialRetryTest.php
@@ -5,6 +5,7 @@ namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
 
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
 use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class ExponentialRetryTest extends TestCase
 {
@@ -17,6 +18,7 @@ class ExponentialRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             0,
             'some-claim'
@@ -46,6 +48,7 @@ class ExponentialRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             $incarnation
         );
@@ -74,6 +77,7 @@ class ExponentialRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             $incarnation
         );
@@ -106,6 +110,7 @@ class ExponentialRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             $incarnation
         );
@@ -162,6 +167,7 @@ class ExponentialRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             10,
             'some-claim'

--- a/Tests/Functional/Retry/LinearRetryTest.php
+++ b/Tests/Functional/Retry/LinearRetryTest.php
@@ -5,6 +5,7 @@ namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
 
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
 use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class LinearRetryTest extends TestCase
 {
@@ -17,6 +18,7 @@ class LinearRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             0,
             'some-claim'
@@ -46,6 +48,7 @@ class LinearRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             $incarnation
         );
@@ -74,6 +77,7 @@ class LinearRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             $incarnation
         );
@@ -106,6 +110,7 @@ class LinearRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             $incarnation
         );
@@ -136,6 +141,7 @@ class LinearRetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             10,
             'some-claim'

--- a/Tests/Functional/Retry/RetryTest.php
+++ b/Tests/Functional/Retry/RetryTest.php
@@ -6,6 +6,7 @@ namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
 use DateInterval;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
 use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class RetryTest extends TestCase
 {
@@ -18,6 +19,7 @@ class RetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-identifier'
         );
 
@@ -37,12 +39,14 @@ class RetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier'
         );
         $jobB = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-second-identifier'
         );
 
@@ -65,6 +69,7 @@ class RetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier'
         );
 
@@ -89,6 +94,7 @@ class RetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             100,
             'claim'
@@ -119,6 +125,7 @@ class RetryTest extends TestCase
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
             100,
             'claim'
@@ -158,6 +165,7 @@ class RetryTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 'some-identifier',
                 1234567
             )
@@ -168,6 +176,7 @@ class RetryTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 'some-identifier'
             )
         );
@@ -190,6 +199,7 @@ class RetryTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 'some-identifier',
                 100
             )
@@ -200,6 +210,7 @@ class RetryTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 'some-identifier',
                 1000
             )

--- a/Tests/Functional/SchedulingTest.php
+++ b/Tests/Functional/SchedulingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
 
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class SchedulingTest extends TestCase
 {
@@ -25,7 +26,8 @@ class SchedulingTest extends TestCase
             new ScheduledJob(
                 self::getJobQueueJob(),
                 self::getQueueName(),
-                self::getDueDate()
+                self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME
             )
         );
 
@@ -43,7 +45,8 @@ class SchedulingTest extends TestCase
             new ScheduledJob(
                 self::getJobQueueJob(),
                 self::getQueueName(),
-                self::getDueDate()
+                self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME
             )
         );
 
@@ -65,7 +68,8 @@ class SchedulingTest extends TestCase
             new ScheduledJob(
                 self::getJobQueueJob(),
                 self::getQueueName(),
-                self::getDueDate()
+                self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME
             )
         );
 
@@ -87,7 +91,8 @@ class SchedulingTest extends TestCase
             new ScheduledJob(
                 self::getJobQueueJob(),
                 self::getQueueName(),
-                self::getDueDate()
+                self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME
             )
         );
 

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -61,7 +61,8 @@ class TestCase extends FunctionalTestCase
         $scheduledJob = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
-            self::getDueDate()
+            self::getDueDate(),
+            Scheduler::DEFAULT_GROUP_NAME
         );
 
         $this->scheduler->schedule($scheduledJob);

--- a/Tests/Functional/UniqueJobsTest.php
+++ b/Tests/Functional/UniqueJobsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
 
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 use Netlogix\JobQueue\Scheduled\Tests\Fixture\JobQueueJob;
 
 class UniqueJobsTest extends TestCase
@@ -18,6 +19,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -40,6 +42,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -49,6 +52,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -68,6 +72,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -78,6 +83,7 @@ class UniqueJobsTest extends TestCase
                 $secondJob,
                 self::getQueueName(),
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -99,6 +105,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 $firstQueueName,
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -109,6 +116,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 $secondQueueName,
                 self::getDueDate(),
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -131,6 +139,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 $firstDueDate,
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -141,6 +150,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 $secondDueDate,
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -163,6 +173,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 $firstDueDate,
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );
@@ -173,6 +184,7 @@ class UniqueJobsTest extends TestCase
                 self::getJobQueueJob(),
                 self::getQueueName(),
                 $secondDueDate,
+                Scheduler::DEFAULT_GROUP_NAME,
                 self::getJobIdentifier()
             )
         );

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "doctrine/dbal": "^2.9",
         "doctrine/orm": "^2.6",
         "flowpack/jobqueue-common": "^3.0",
-        "neos/flow": "^5.3 || ^6.3 || ^7.3 || ^8.0",
+        "neos/flow": "^6.3 || ^7.3 || ^8.0",
         "php": "^7.4 || ^8.0 || ^8.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.4 || ^8.0 || ^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=7.2"
+        "phpunit/phpunit": ">=10.0"
     },
     "suggest": {
         "netlogix/supervisor": "Create supervisord programs that run the 'scheduler:pollforincomingjobs' command"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "neos/flow": "^5.3 || ^6.3 || ^7.3 || ^8.0",
         "php": "^7.4 || ^8.0 || ^8.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=7.2"
+    },
     "suggest": {
         "netlogix/supervisor": "Create supervisord programs that run the 'scheduler:pollforincomingjobs' command"
     },


### PR DESCRIPTION
Each job now has to be placed in one specific group. Groups are meant to allow for parallelization of workers.