### PR TITLE
feat: Custom databse connection

### DIFF
--- a/Classes/Domain/Scheduler.php
+++ b/Classes/Domain/Scheduler.php
@@ -36,9 +36,18 @@ class Scheduler
      */
     protected $timeBaseForDueDateCalculation;
 
+    /**
+     * Use the same database credentials as the entity manager but create
+     * a new connection. All SQL queries issued by the scheduler are meant
+     * to be atomic. Having the buried within application transactions hinders
+     * the synchronization of multiple parallel scheduler instances.
+     */
     public function injectEntityManager(EntityManagerInterface $entityManager): void
     {
-        $this->dbal = $entityManager->getConnection();
+        $this->dbal = clone $entityManager->getConnection();
+        $this->dbal->close();
+        $this->dbal->setAutoCommit(true);
+        $this->dbal->connect();
     }
 
     public function injectTimeBaseForDueDateCalculation(TimeBaseForDueDateCalculation $timeBaseForDueDateCalculation): void


### PR DESCRIPTION
The scheduler used to rely on the applications datbase connection.

When app processes start transaction that take a couple of seconds, every scheduling call done within this app process is captured by this translaction, which potentially locks the scheduler table for worker processes.

This change now uses the same database credentials as the entity manager but creates a new connection object. All SQL queries issued by the scheduler are meant to be atomic. Having the buried within application transactions hinders the synchronization of multiple parallel scheduler instances.