### PR TITLE
fix: DBAL connection retries when connection was lost

### DIFF
--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -10,27 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 7.4, 8.0, 8.1 ]
-        flow-version: [ 6.3, 7.3, 8.0 ]
+        php-version: [ 8.2, 8.3 ]
+        flow-version: [ 8.3 ]
         mysql-version: [5.7, 8.0]
-        exclude:
-          # Disable Flow 6.3 on PHP 8.0, as only ^7.2 is supported
-          - php-version: 8.0
-            flow-version: 6.3
-          - php-version: 8.1
-            flow-version: 6.3
-
-          # Disable Flow 7.0 on PHP 7.2, as 7.3 is required
-          - php-version: 7.2
-            flow-version: 7.3
-
-          # Disable Flow 8.0 on PHP 7, as 8.0 is required
-          - php-version: 7.2
-            flow-version: 8.0
-          - php-version: 7.3
-            flow-version: 8.0
-          - php-version: 7.4
-            flow-version: 8.0
 
     services:
       mysql:

--- a/Classes/Domain/Scheduler.php
+++ b/Classes/Domain/Scheduler.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Netlogix\JobQueue\Scheduled\Domain;
 
 use DateTimeImmutable;
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use Neos\Flow\Utility\Algorithms;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
 use Netlogix\JobQueue\Scheduled\DueDateCalculation\TimeBaseForDueDateCalculation;
+use Netlogix\JobQueue\Scheduled\Service\Connection;
 
 use function array_filter;
 use function in_array;
@@ -36,18 +35,9 @@ class Scheduler
      */
     protected $timeBaseForDueDateCalculation;
 
-    /**
-     * Use the same database credentials as the entity manager but create
-     * a new connection. All SQL queries issued by the scheduler are meant
-     * to be atomic. Having the buried within application transactions hinders
-     * the synchronization of multiple parallel scheduler instances.
-     */
-    public function injectEntityManager(EntityManagerInterface $entityManager): void
+    public function injectConnection(Connection $connection): void
     {
-        $this->dbal = clone $entityManager->getConnection();
-        $this->dbal->close();
-        $this->dbal->setAutoCommit(true);
-        $this->dbal->connect();
+        $this->dbal = $connection;
     }
 
     public function injectTimeBaseForDueDateCalculation(TimeBaseForDueDateCalculation $timeBaseForDueDateCalculation): void

--- a/Classes/Service/Connection.php
+++ b/Classes/Service/Connection.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\Service;
+
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Connection as DBALConnection;
+use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * This connection uses the same database credentials as the FLOW
+ * entity manager but create a new connection instance.
+ *
+ * All SQL queries issued by the scheduler are meant to be atomic.
+ * Having them buried within application transactions hinders
+ * the synchronization of multiple parallel scheduler instances.
+ *
+ * Since there can be some time between one scheduler call and another
+ * one, having to reconnect is to be expected.
+ */
+class Connection
+{
+    /**
+     * @var DBALConnection
+     */
+    protected $dbal;
+
+    /**
+     * Use the same database credentials as the entity manager but create
+     * a new connection. All SQL queries issued by the scheduler are meant
+     * to be atomic. Having the buried within application transactions hinders
+     * the synchronization of multiple parallel scheduler instances.
+     */
+    public function injectEntityManager(EntityManagerInterface $entityManager): void
+    {
+        $this->dbal = clone $entityManager->getConnection();
+        $this->dbal->close();
+        $this->dbal->setAutoCommit(true);
+        $this->dbal->connect();
+    }
+
+    public function fetchOne(string $query, array $params = [], array $types = [])
+    {
+        return $this->withAutoReconnect(function () use ($query, $params, $types) {
+            return $this->dbal->fetchOne($query, $params, $types);
+        });
+    }
+
+    public function executeQuery($sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null)
+    {
+        return $this->withAutoReconnect(function () use ($sql, $params, $types, $qcp) {
+            return $this->dbal->executeQuery($sql, $params, $types, $qcp);
+        });
+    }
+
+    /**
+     * Try and retry an SQL query in case of connection timeouts. This avoids
+     * multiple PING requests in rapid succession. Since all query performed
+     * are meant to be atomic anyway, there should be no lost data and no data
+     * duplication.
+     *
+     * @template T
+     * @param callable(): T $dbalInteraction
+     * @return T
+     */
+    protected function withAutoReconnect(callable $dbalInteraction)
+    {
+        try {
+            return $dbalInteraction();
+        } catch (ConnectionLost $e) {
+            $this->dbal->connect();
+            return $dbalInteraction();
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "doctrine/dbal": "^2.9",
         "doctrine/orm": "^2.6",
         "flowpack/jobqueue-common": "^3.0",
-        "neos/flow": "^6.3 || ^7.3 || ^8.0",
-        "php": "^7.4 || ^8.0 || ^8.1"
+        "neos/flow": "~8.3",
+        "php": "~8.2 || ~8.3"
     },
     "require-dev": {
         "phpunit/phpunit": ">=10.0"


### PR DESCRIPTION
Try and retry an SQL query in case of connection timeouts. This avoids multiple PING requests in rapid succession. Since all query performed are meant to be atomic anyway, there should be no lost data and no data duplication.