### PR TITLE
fix: Add mirrored indexes for claiming a lot of jobs

### DIFF
--- a/Classes/Domain/Model/ScheduledJob.php
+++ b/Classes/Domain/Model/ScheduledJob.php
@@ -16,7 +16,9 @@ use Neos\Flow\Utility\Algorithms;
  *     name=ScheduledJob::TABLE_NAME,
  *     indexes={
  *          @ORM\Index(name="idx_groupname", columns={"groupname", "identifier"}),
- *          @ORM\Index(name="idx_claimed", columns={"claimed", "identifier"})
+ *          @ORM\Index(name="idx_claimed", columns={"claimed", "identifier"}),
+ *          @ORM\Index(name="idx_for_retrieve", columns={"claimed", "groupname"}),
+ *          @ORM\Index(name="idx_for_update", columns={"groupname", "claimed", "duedate"})
  *     }
  * )
  */

--- a/Migrations/Mysql/Version20241018152838.php
+++ b/Migrations/Mysql/Version20241018152838.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add mirrored index for retrieving and updating claim statemens.
+ *
+ * The index "idx_for_update" helps for the claiming query statement like
+ * "UPDATE SET claimed = ? WHERE groupname = ? AND claimed = 0 AND duedate <= ?".
+ * This needs to order a huge chunk of jobs.
+ *
+ * The index "idx_for_retrieve" helps for the retrieving query statement like
+ * "SELECT * FROM WHERE claimed = ? AND groupname = ?".
+ * This needs to quickly drill down to a single job.
+ */
+final class Version20241018152838 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('CREATE INDEX idx_for_update ON netlogix_jobqueue_scheduled_job (groupname, claimed, duedate)');
+        $this->addSql('CREATE INDEX idx_for_retrieve ON netlogix_jobqueue_scheduled_job (claimed, groupname)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('DROP INDEX idx_for_update ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('DROP INDEX idx_for_retrieve ON netlogix_jobqueue_scheduled_job');
+    }
+}


### PR DESCRIPTION
Adding new claim values to a huge list of jobs ready to be worked on will always require ordering the jobs table by date before updating the very first record.

Retrieveing the one previously claimed record should start with the claim row to segment all nun-claimed records away to allow the search mechanism to ignore all those values.