### PR TITLE
feat: Rename Retry to SchedulingCoordinator

### DIFF
--- a/Classes/Command/SchedulerCommandController.php
+++ b/Classes/Command/SchedulerCommandController.php
@@ -14,7 +14,7 @@ use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Netlogix\JobQueue\Scheduled\AsScheduledJob\SchedulingInformation;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
-use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\SchedulingCoordinator;
 use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 /**
@@ -103,7 +103,7 @@ class SchedulerCommandController extends CommandController
     protected function queueDueJobs(string $groupName, int $endTime): int
     {
         $numberOfHandledJobs = 0;
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
 
         while ($next = $this->scheduler->next($groupName)) {
             try {

--- a/Classes/Domain/SchedulingCoordinator.php
+++ b/Classes/Domain/SchedulingCoordinator.php
@@ -9,7 +9,7 @@ use LogicException;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
 use Netlogix\JobQueue\Scheduled\DueDateCalculation\TimeBaseForDueDateCalculation;
 
-class Retry
+class SchedulingCoordinator
 {
     const DEFAULT_BACKOFF_STRATEGY = 'linear';
     const DEFAULT_NUMBER_OF_RETRIES = -1;

--- a/Tests/Functional/SchedulingCoordinator/ExponentialRetryTest.php
+++ b/Tests/Functional/SchedulingCoordinator/ExponentialRetryTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\SchedulingCoordinator;
 
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
-use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\SchedulingCoordinator;
 use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class ExponentialRetryTest extends TestCase
@@ -24,7 +24,7 @@ class ExponentialRetryTest extends TestCase
             'some-claim'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'exponential',
@@ -53,7 +53,7 @@ class ExponentialRetryTest extends TestCase
             $incarnation
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'exponential',
@@ -82,7 +82,7 @@ class ExponentialRetryTest extends TestCase
             $incarnation
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'exponential',
@@ -115,7 +115,7 @@ class ExponentialRetryTest extends TestCase
             $incarnation
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'exponential',
@@ -173,7 +173,7 @@ class ExponentialRetryTest extends TestCase
             'some-claim'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'exponential',

--- a/Tests/Functional/SchedulingCoordinator/LinearRetryTest.php
+++ b/Tests/Functional/SchedulingCoordinator/LinearRetryTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\SchedulingCoordinator;
 
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
-use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\SchedulingCoordinator;
 use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
 class LinearRetryTest extends TestCase
@@ -24,7 +24,7 @@ class LinearRetryTest extends TestCase
             'some-claim'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',
@@ -53,7 +53,7 @@ class LinearRetryTest extends TestCase
             $incarnation
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',
@@ -82,7 +82,7 @@ class LinearRetryTest extends TestCase
             $incarnation
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',
@@ -115,7 +115,7 @@ class LinearRetryTest extends TestCase
             $incarnation
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',
@@ -147,7 +147,7 @@ class LinearRetryTest extends TestCase
             'some-claim'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',

--- a/Tests/Functional/SchedulingCoordinator/SchedulingTest.php
+++ b/Tests/Functional/SchedulingCoordinator/SchedulingTest.php
@@ -1,14 +1,13 @@
 <?php
 declare(strict_types=1);
 
-namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\SchedulingCoordinator;
 
-use DateInterval;
 use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
-use Netlogix\JobQueue\Scheduled\Domain\Retry;
+use Netlogix\JobQueue\Scheduled\Domain\SchedulingCoordinator;
 use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
 
-class RetryTest extends TestCase
+class SchedulingTest extends TestCase
 {
     /**
      * @test
@@ -23,7 +22,7 @@ class RetryTest extends TestCase
             'my-identifier'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->markJobForRescheduling($job);
 
         $all = $this->findAll();
@@ -50,7 +49,7 @@ class RetryTest extends TestCase
             'my-second-identifier'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([]));
         $retry->markJobForRescheduling($jobA);
         $retry->markJobForRescheduling($jobB);
@@ -73,7 +72,7 @@ class RetryTest extends TestCase
             'my-first-identifier'
         );
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([]));
         $retry->markJobForRescheduling($job);
         $retry->scheduleAll();
@@ -102,7 +101,7 @@ class RetryTest extends TestCase
         $this->persistenceManager->add($job);
         $this->persistenceManager->persistAll();
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',
@@ -133,7 +132,7 @@ class RetryTest extends TestCase
         $this->persistenceManager->add($job);
         $this->persistenceManager->persistAll();
 
-        $retry = new Retry($this->scheduler);
+        $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [
                 'backoffStrategy' => 'linear',

--- a/Tests/Functional/SchedulingCoordinator/TestCase.php
+++ b/Tests/Functional/SchedulingCoordinator/TestCase.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Netlogix\JobQueue\Scheduled\Tests\Functional\Retry;
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional\SchedulingCoordinator;
 
 use DateInterval;
 use DateTimeImmutable;

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "doctrine/orm": "^2.6",
         "flowpack/jobqueue-common": "^3.0",
         "neos/flow": "~8.3",
+        "netlogix/retry": "~1.0",
         "php": "~8.2 || ~8.3"
     },
     "require-dev": {


### PR DESCRIPTION
The object formerly known as Retry actually calls the scheduler in way to have jobs scheduled afterwards with proper retry settings.