### PR TITLE
fix: Prevent parallel execution of re-scheduled jobs

### DIFF
--- a/Classes/Domain/Model/ScheduledJob.php
+++ b/Classes/Domain/Model/ScheduledJob.php
@@ -17,8 +17,8 @@ use Neos\Flow\Utility\Algorithms;
  *     indexes={
  *          @ORM\Index(name="idx_groupname", columns={"groupname", "identifier"}),
  *          @ORM\Index(name="idx_claimed", columns={"claimed", "identifier"}),
- *          @ORM\Index(name="idx_for_retrieve", columns={"claimed", "groupname"}),
- *          @ORM\Index(name="idx_for_update", columns={"groupname", "claimed", "duedate"})
+ *          @ORM\Index(name="idx_for_retrieve", columns={"claimed", "groupname", "running"}),
+ *          @ORM\Index(name="idx_for_update", columns={"groupname", "claimed", "duedate", "running"})
  *     }
  * )
  */
@@ -67,6 +67,11 @@ class ScheduledJob
      */
     protected $claimed = '';
 
+    /**
+     * @var bool
+     */
+    protected $running = false;
+
     public function __construct(
         JobInterface $job,
         string $queue,
@@ -74,7 +79,8 @@ class ScheduledJob
         string $groupName,
         string $identifier = '',
         int $incarnation = 0,
-        string $claimed = ''
+        string $claimed = '',
+        bool $running = false
     ) {
         $this->job = $job;
         $this->queue = $queue;
@@ -83,6 +89,7 @@ class ScheduledJob
         $this->identifier = $identifier ?: Algorithms::generateUUID();
         $this->incarnation = $incarnation;
         $this->claimed = $claimed;
+        $this->running = $running;
     }
 
     public function getGroupName(): string
@@ -118,5 +125,10 @@ class ScheduledJob
     public function getClaimed(): string
     {
         return $this->claimed;
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->running;
     }
 }

--- a/Migrations/Mysql/Version20250806123506.php
+++ b/Migrations/Mysql/Version20250806123506.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add "running" flag to jobs, in addition to the already existing
+ * "claimed" tag. Jobs now get "claimed" as well as marked as "running"
+ * when working on them starts. Re-scheduling a claimed job empties the
+ * "claimed" tag but keeps the "running" flag as is. This results in a
+ * "one more, please" situation but prevents the additional job from
+ * being claimed again as long as the previous one is still being
+ * worked on.
+ */
+final class Version20250806123506 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MariaDb1027Platform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('DROP INDEX idx_for_retrieve ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('DROP INDEX idx_for_update ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('ALTER TABLE netlogix_jobqueue_scheduled_job ADD running TINYINT(1) NOT NULL');
+        $this->addSql('CREATE INDEX idx_for_retrieve ON netlogix_jobqueue_scheduled_job (claimed, groupname, running)');
+        $this->addSql('CREATE INDEX idx_for_update ON netlogix_jobqueue_scheduled_job (groupname, claimed, duedate, running)'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MariaDb1027Platform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('DROP INDEX idx_for_retrieve ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('DROP INDEX idx_for_update ON netlogix_jobqueue_scheduled_job');
+        $this->addSql('ALTER TABLE netlogix_jobqueue_scheduled_job DROP running');
+        $this->addSql('CREATE INDEX idx_for_retrieve ON netlogix_jobqueue_scheduled_job (claimed, groupname)');
+        $this->addSql('CREATE INDEX idx_for_update ON netlogix_jobqueue_scheduled_job (groupname, claimed, duedate)');
+    }
+}

--- a/Tests/Functional/ReschedulingClaimedTest.php
+++ b/Tests/Functional/ReschedulingClaimedTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\Flow\Utility\Now;
+use Netlogix\JobQueue\Scheduled\Domain\Model\ScheduledJob;
+use Netlogix\JobQueue\Scheduled\Domain\Scheduler;
+
+class ReschedulingClaimedTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function Scheduling_already_claimed_jobs_resets_the_claim_but_keeps_the_running_flag(): void
+    {
+        // create a new job
+        $this->scheduler->schedule($this->job());
+
+        // make sure it's claimed
+        $first = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        self::assertInstanceOf(ScheduledJob::class, $first);
+        assert($first instanceof ScheduledJob);
+
+        // reschedule to set the claim to empty but keep the running flag
+        $this->scheduler->schedule($this->job());
+
+        $row = $this->objectManager
+            ->get(EntityManagerInterface::class)
+            ->getConnection()
+            ->fetchAllAssociative('SELECT incarnation, claimed, running FROM ' . ScheduledJob::TABLE_NAME);
+
+        self::assertEquals(
+            [
+                [
+                    'incarnation' => 0,
+                    'claimed' => '',
+                    'running' => 1,
+                ],
+            ],
+            $row
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function Claiming_only_works_for_jobs_that_are_not_running_even_if_jobs_are_unclaimed(): void
+    {
+        // create a new job
+        $this->scheduler->schedule($this->job());
+
+        // make sure it's claimed
+        $first = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        self::assertInstanceOf(ScheduledJob::class, $first);
+        assert($first instanceof ScheduledJob);
+
+        // reschedule to set the claim to empty but keep the running flag
+        $this->scheduler->schedule($this->job());
+
+        // now the job cannot be claimed again
+        $second = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        self::assertNull($second);
+
+        // release unsets the claim and unsets the running flag
+        $this->scheduler->release($first);
+
+        // re-reclaim works again
+        $third = $this->scheduler->next(Scheduler::DEFAULT_GROUP_NAME);
+        self::assertInstanceOf(ScheduledJob::class, $third);
+        assert($third instanceof ScheduledJob);
+    }
+
+    protected function job(): ScheduledJob
+    {
+        return new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->objectManager->get(Now::class),
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            0,
+        );
+    }
+}

--- a/Tests/Functional/SchedulingCoordinator/ExponentialRetryTest.php
+++ b/Tests/Functional/SchedulingCoordinator/ExponentialRetryTest.php
@@ -44,13 +44,25 @@ class ExponentialRetryTest extends TestCase
     public function Jobs_with_negative_retries_get_retried_infinitely(): void
     {
         $incarnation = pow(2, 15);
+        $initialJob = new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            $incarnation,
+            'first-claim'
+        );
+        $this->scheduler->schedule($initialJob);
+
         $job = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
-            $incarnation
+            $incarnation,
+            'second-claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);
@@ -73,13 +85,25 @@ class ExponentialRetryTest extends TestCase
     public function Default_interval_is_zero(): void
     {
         $incarnation = pow(2, 15);
+        $initialJob = new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            0,
+            'first-claim'
+        );
+        $this->scheduler->schedule($initialJob);
+
         $job = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
-            $incarnation
+            $incarnation,
+            'second-claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);
@@ -106,15 +130,27 @@ class ExponentialRetryTest extends TestCase
     {
         $retryInterval = 100;
 
+        $initialJob = new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            0,
+            '',
+            true
+        );
+        $this->scheduler->schedule($initialJob);
+
         $job = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
-            $incarnation
+            $incarnation,
+            'second-claim'
         );
-
         $retry = new SchedulingCoordinator($this->scheduler);
         $retry->injectQueueManager($this->queueManager([
             'scheduledJobs' => [

--- a/Tests/Functional/SchedulingCoordinator/LinearRetryTest.php
+++ b/Tests/Functional/SchedulingCoordinator/LinearRetryTest.php
@@ -44,13 +44,25 @@ class LinearRetryTest extends TestCase
     public function Jobs_with_negative_retries_get_retried_infinitely(): void
     {
         $incarnation = pow(2, 15);
+        $initialJob = new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            0,
+            'first-claim'
+        );
+        $this->scheduler->schedule($initialJob);
+
         $job = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
-            $incarnation
+            $incarnation,
+            'second-claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);
@@ -73,13 +85,25 @@ class LinearRetryTest extends TestCase
     public function Default_interval_is_zero(): void
     {
         $incarnation = pow(2, 15);
+        $initialJob = new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            0,
+            'first-claim'
+        );
+        $this->scheduler->schedule($initialJob);
+
         $job = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
-            $incarnation
+            $incarnation,
+            'second-claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);
@@ -106,13 +130,26 @@ class LinearRetryTest extends TestCase
         $retryInterval = 100;
 
         $incarnation = pow(2, 15);
+        $initialJob = new ScheduledJob(
+            self::getJobQueueJob(),
+            self::getQueueName(),
+            $this->now,
+            Scheduler::DEFAULT_GROUP_NAME,
+            'my-first-identifier',
+            0,
+            'first-claim',
+            true
+        );
+        $this->scheduler->schedule($initialJob);
+
         $job = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
             'my-first-identifier',
-            $incarnation
+            $incarnation,
+            'second-claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);

--- a/Tests/Functional/SchedulingCoordinator/SchedulingTest.php
+++ b/Tests/Functional/SchedulingCoordinator/SchedulingTest.php
@@ -39,14 +39,18 @@ class SchedulingTest extends TestCase
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
-            'my-first-identifier'
+            'my-first-identifier',
+            0,
+            'first-claim'
         );
         $jobB = new ScheduledJob(
             self::getJobQueueJob(),
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
-            'my-second-identifier'
+            'my-second-identifier',
+            0,
+            'second-claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);
@@ -69,7 +73,9 @@ class SchedulingTest extends TestCase
             self::getQueueName(),
             $this->now,
             Scheduler::DEFAULT_GROUP_NAME,
-            'my-first-identifier'
+            'my-first-identifier',
+            0,
+            'claim'
         );
 
         $retry = new SchedulingCoordinator($this->scheduler);

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Netlogix\JobQueue\Scheduled\Tests\Functional;
 
 use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
 use Neos\Flow\Utility\Now;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Persistence\QueryResultInterface;
@@ -27,6 +28,11 @@ class TestCase extends FunctionalTestCase
         $scheduler = $this->objectManager->get(Scheduler::class);
         assert($scheduler instanceof Scheduler);
         $this->scheduler = $scheduler;
+
+        $this->objectManager
+            ->get(EntityManagerInterface::class)
+            ->getConnection()
+            ->executeStatement('DELETE FROM ' . ScheduledJob::TABLE_NAME);
     }
 
     protected static function getJobQueueJob(): JobQueueJob


### PR DESCRIPTION
This adds a "running" flag to jobs, in addition to the already existing "claimed" tag. Jobs now get "claimed" as well as marked as "running" when working on them starts. Re-scheduling a claimed job empties the "claimed" tag but keeps the "running" flag as is. This results in  a "one more, please" situation but prevents the additional job from being claimed again as long as the previous one is still being worked on.